### PR TITLE
Fix: replace hard-coded banner types with enum

### DIFF
--- a/src/Components/BanerBookBlock/BanerBookBlock.tsx
+++ b/src/Components/BanerBookBlock/BanerBookBlock.tsx
@@ -1,11 +1,16 @@
 import './BanerBookBlock.css'
 
 
+export enum BanerType {
+    Salary = 'Акція',
+    New = 'Новинка',
+    Exclusive = 'Ексклюзив',
+}
 
 
 export type BanerProps = {
 
-    textBaner?: 'Акція' | 'Новинка' | 'Ексклюзив'
+    textBaner?: BanerType | null
 }
 
 export default function BanerBookBlock({ textBaner }: BanerProps) {

--- a/src/Components/Main/Main.tsx
+++ b/src/Components/Main/Main.tsx
@@ -9,7 +9,7 @@ import { Navigation, Pagination } from 'swiper/modules'
 import 'swiper/css/navigation'
 import 'swiper/css/pagination'
 import type { Swiper as SwiperType } from 'swiper'
-import { BanerProps } from "../BanerBookBlock/BanerBookBlock";
+import { BanerProps, BanerType } from "../BanerBookBlock/BanerBookBlock";
 
 type MainProps = {
     children?: ReactNode;
@@ -60,9 +60,9 @@ export default function Main({ children }: MainProps) {
                 <div className="custom-pagination-container"></div>
             </div>
 
-            <ShowPagePopularity textBaner="Ексклюзив" />
-            <ShowPagePopularity textBaner="Акція" />
-            <ShowPagePopularity textBaner="Новинка" />
+            <ShowPagePopularity textBaner={BanerType.Exclusive} />
+            <ShowPagePopularity textBaner={BanerType.Salary} />
+            <ShowPagePopularity textBaner={BanerType.New} />
         </main>
     )
 }

--- a/src/Components/ShowPagePopularity/ShowPagePopularity.tsx
+++ b/src/Components/ShowPagePopularity/ShowPagePopularity.tsx
@@ -2,7 +2,6 @@ import "./ShowPagePopularity.css"
 import BlockBook from "../BlockBook/BlockBook"
 import { books, BooksParam, calcSalary } from "../../Data/book"
 import BanerBookBlock from "../BanerBookBlock/BanerBookBlock"
-import { BanerProps } from "../BanerBookBlock/BanerBookBlock"
 import { Swiper, SwiperSlide, useSwiper } from 'swiper/react'
 import 'swiper/css'
 import { Navigation, Pagination } from 'swiper/modules'
@@ -10,9 +9,9 @@ import 'swiper/css/navigation'
 import 'swiper/css/pagination'
 import type { Swiper as SwiperType } from 'swiper'
 import { useEffect, useRef, useState } from "react"
+import { BanerType } from "../BanerBookBlock/BanerBookBlock"
 
-
-export default function ShowPagePopularity({ textBaner }: BanerProps) {
+export default function ShowPagePopularity({ textBaner }: { textBaner: BanerType | null }) {
 
     const swiperRef = useRef<SwiperType | null>(null)
 
@@ -20,13 +19,13 @@ export default function ShowPagePopularity({ textBaner }: BanerProps) {
         if (!textBaner) return []
 
         switch (textBaner) {
-            case 'Ексклюзив':
+            case BanerType.Exclusive:
                 return books.filter(book => book.price > 300)
 
-            case 'Акція':
+            case BanerType.Salary:
                 return books.filter(book => book.salarydiscount === true)
 
-            case 'Новинка':
+            case BanerType.New:
                 return books.filter(book => book.price > 100)
 
             default:


### PR DESCRIPTION
## Refactored Banner Logic

I have refactored the banner filtering logic to align with **SOLID principles**, specifically the **Open/Closed Principle (OCP)** and the **Dependency Inversion Principle (DIP)**.

By replacing volatile, hard-coded string literals with a centralized `BanerType` Enum, the [`ShowPagePopularity`](src/Components/ShowPagePopularity/ShowPagePopularity.tsx) component now depends on a stable abstraction (the Enum type) rather than concrete strings, satisfying **DIP**.

Additionally, this centralization allows the application to be easily extended with new banner types in the definition without necessitating invasive changes or risking errors across consuming components, adhering to **OCP**.

### Changes Implemented

* **Created a `BanerType` Enum:**
* https://github.com/Svyatkk/library-market/blob/7077f01bd5e73bded01f069cfafd680e8ac53529/src/Components/BanerBookBlock/BanerBookBlock.tsx#L4-L8
    I defined a centralized Enum in [`BanerBookBlock.tsx`](src/Components/BanerBookBlock/BanerBookBlock.tsx) to manage all banner categories:
    * `Salary`
    * `New`
    * `Exclusive`

* **Updated Typing:**
    The `BanerProps` interface now strictly accepts `BanerType` instead of generic strings.

* **Refactored Logic:**
    I updated the [`filterbooks`]https://github.com/Svyatkk/library-market/blob/7077f01bd5e73bded01f069cfafd680e8ac53529/src/Components/ShowPagePopularity/ShowPagePopularity.tsx#L18 function in [`ShowPagePopularity.tsx`](https://github.com/Svyatkk/Deckor-Market/blob/main/src/Components/ShowPagePopularity/ShowPagePopularity.tsx) to use Enum values in the switch-case statements.

---
Closes #1