### PR TITLE
refactor: separate filtering logic from UI in ShowCategoryBooks

### DIFF
--- a/src/Components/ShowCategoryBooks/ShowCategoryBooks.tsx
+++ b/src/Components/ShowCategoryBooks/ShowCategoryBooks.tsx
@@ -6,7 +6,7 @@ import Nav from '../Nav/Nav';
 import { catalogs } from '../../Data/book';
 import BlockBook from '../BlockBook/BlockBook';
 import './ShowCategoryBooks.css';
-
+import { filterBooksByCategory } from '../../services/bookFilter.service'
 
 
 
@@ -17,14 +17,9 @@ export default function ShowCategoryBooks() {
     const decodedMain = mainCategory ? decodeURIComponent(mainCategory) : '';
     const decodedSub = subCategory ? decodeURIComponent(subCategory) : null
 
-    const filteredBooks = books.filter(book => {
-        return book.catalog.some(cat => {
-            if (decodedSub) {
-                return cat.mainCategory === decodedMain && cat.subCategory === decodedSub
-            }
-            return cat.mainCategory === decodedMain
-        })
-    })
+    const filteredBooks = filterBooksByCategory(books, decodedMain, decodedSub);
+
+
 
     return (
         <>

--- a/src/services/bookFilter.service.ts
+++ b/src/services/bookFilter.service.ts
@@ -1,0 +1,16 @@
+import { BooksParam } from "../Data/book";
+
+
+export function filterBooksByCategory(
+    books: BooksParam[],
+    mainCategory: string,
+    subCategory?: string | null
+): BooksParam[] {
+    return books.filter(book =>
+        book.catalog.some(cat =>
+            subCategory
+                ? cat.mainCategory === mainCategory && cat.subCategory === subCategory
+                : cat.mainCategory === mainCategory
+        )
+    );
+}


### PR DESCRIPTION
## Refactored: Fixed SRP Violation in ShowCategoryBooks

I have refactored the [`ShowCategoryBooks`](https://github.com/Svyatkk/Deckor-Market/blob/main/src/Components/ShowCategoryBooks/ShowCategoryBooks.tsx) component to address a violation of the **Single Responsibility Principle (SRP)**. 

Previously, this component tightly coupled UI rendering with domain business logic (specifically, the complex filtering of books based on URL parameters). By extracting this domain logic into a dedicated service, the component now strictly focuses on presentation, adhering to SOLID principles.

### Changes Implemented

* **Created a Filtering Service:** I created a new file, [`bookFilter.service.ts`](src/services/bookFilter.service.ts), which exports a pure `filterBooksByCategory` function. This function now encapsulates the core logic of filtering the book array based on `mainCategory` and optional `subCategory`.

* **Refactored Component Logic:** In `ShowCategoryBooks.tsx`, I removed the inline filtering logic. The component now only handles reading/decoding the URL parameters (`useParams`) and delegates the actual data processing to the new `filterBooksByCategory` service.

* **Improved UI Focus:**
  The [`ShowCategoryBooks`](https://github.com/Svyatkk/Deckor-Market/blob/main/src/Components/ShowCategoryBooks/ShowCategoryBooks.tsx) component is now much cleaner, focusing solely on iterating over the `filteredBooks` array and rendering the `BlockBook` components.

---
Closes #3