### PR TITLE
refactor: extract book fetching logic to service

### DIFF
--- a/src/Components/CatalogPanel/CatalogPanel.tsx
+++ b/src/Components/CatalogPanel/CatalogPanel.tsx
@@ -25,6 +25,7 @@ export default function CatalogPanel({ isOpen, onClose }: Props) {
 
                 </div>
 
+
                 <div className="wrapperButtons">
                     {catalogs.map(catalog =>
                         <>

--- a/src/Components/Pages/BookInformation.tsx
+++ b/src/Components/Pages/BookInformation.tsx
@@ -6,21 +6,15 @@ import './BookInformation.css';
 import Nav from '../Nav/Nav';
 import { catalogs } from '../../Data/book';
 import { Link } from 'react-router-dom';
-
+import { getBookById } from '../../services/book.service';
 export default function BookInformation() {
 
     const { id } = useParams();
 
 
+    const currentId = Number(id);
+    const currentBook = getBookById(currentId);
 
-
-
-    const currentId = Number(id)
-
-
-    const currentBook = books.find(
-        book => book.id === currentId
-    );
     if (!currentBook) {
         return <h2 className="titleBook">Книгу не знайдено</h2>;
     }

--- a/src/services/book.service.ts
+++ b/src/services/book.service.ts
@@ -1,0 +1,7 @@
+import { books, BooksParam } from '../Data/book';
+
+export const getBookById = (id: number): BooksParam | undefined => {
+    return books.find(book => book.id === id);
+};
+
+


### PR DESCRIPTION
## Refactor: Address SRP Violation in BookInformation

I have refactored the [`BookInformation`](https://github.com/Svyatkk/library-market/blob/091f47c5e2ecacdf8559e2b39652555fba7e15b2/src/Components/Pages/BookInformation.tsx#L10) component to align with the **Single Responsibility Principle (SRP)**. 

Previously, this component tightly coupled UI rendering with domain data retrieval (specifically, searching for a book within a static array). By extracting this data fetching logic into a dedicated external service, the component is now decoupled from the underlying data structure and focuses exclusively on presentation.

### Changes Implemented

* **Created Data Retrieval Service:** I implemented a new [`getBookById`](https://github.com/Svyatkk/library-market/blob/091f47c5e2ecacdf8559e2b39652555fba7e15b2/src/services/book.service.ts#L3) function in a dedicated service file (e.g., [`book.service.ts`](src/services/book.service.ts)). This function encapsulates the domain logic required to locate a book by its ID.

* **Refactored Component Logic:** In [`BookInformation`](https://github.com/Svyatkk/library-market/blob/091f47c5e2ecacdf8559e2b39652555fba7e15b2/src/Components/Pages/BookInformation.tsx#L10), I removed the inline array querying (`books.find`). The component now strictly handles extracting the route parameter [`useParams`](https://github.com/Svyatkk/library-market/blob/091f47c5e2ecacdf8559e2b39652555fba7e15b2/src/Components/Pages/BookInformation.tsx#L12), delegating the data fetching to the new service, and managing the "Not Found" fallback UI alongside rendering the book details and category breadcrumbs.

---
Closes #5